### PR TITLE
echoserver: Propagate all http headers to the gRPC server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.8"
 services:
 
   echoserver:
-    image: golang:1.18.3-bullseye
+    image: golang:1.19.0-bullseye
     ports:
       - ${GRPC_PORT:-5000}:5000
     volumes:
@@ -16,7 +16,7 @@ services:
     command: go run ./echoserver
 
   echocaller:
-    image: golang:1.18.3-bullseye
+    image: golang:1.19.0-bullseye
     ports:
       - ${ECHOCALLER_GRPC_PORT:-5001}:5000
     volumes:

--- a/echocaller/Dockerfile
+++ b/echocaller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3-bullseye AS builder
+FROM golang:1.19.0-bullseye AS builder
 
 ENV GOOS=linux
 ENV GOARCH=amd64

--- a/echoserver/Dockerfile
+++ b/echoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3-bullseye AS builder
+FROM golang:1.19.0-bullseye AS builder
 
 ENV GOOS=linux
 ENV GOARCH=amd64

--- a/echoserver/internal/server/server.go
+++ b/echoserver/internal/server/server.go
@@ -24,6 +24,10 @@ var (
 	_ servergroup.Stopper = (*Server)(nil)
 )
 
+var allowAllHeaderMatcher = func(key string) (string, bool) {
+	return key, true
+}
+
 func NewServer(port int) *Server {
 	grpcServer := grpc.NewServer()
 
@@ -31,7 +35,9 @@ func NewServer(port int) *Server {
 	channelz.RegisterChannelzServiceToServer(grpcServer)
 	echoserverpb.RegisterEchoServerServer(grpcServer, &echoserver{})
 
-	mux := runtime.NewServeMux()
+	mux := runtime.NewServeMux(
+		runtime.WithIncomingHeaderMatcher(allowAllHeaderMatcher),
+	)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if httputil.IsGRPCRequest(r) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/110y/echoserver
 
-go 1.18
+go 1.19
 
 require (
 	github.com/110y/run v1.0.0


### PR DESCRIPTION
- echoserver: Propagate all http headers to the gRPC server
- Update Go to 1.19