### PR TITLE
echoserver: fix the header propagation for the authorization header

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*
+
+!/Makefile
+!/echoserver
+!/echocaller
+!/go.mod
+!/go.sum
+!/internal
+!/vendor

--- a/echocaller/Dockerfile
+++ b/echocaller/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.19.0-bullseye AS builder
 
-ENV GOOS=linux
-ENV GOARCH=amd64
-
 WORKDIR /go/src/github.com/110y/echoserver
 
 COPY go.mod go.mod

--- a/echoserver/Dockerfile
+++ b/echoserver/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.19.0-bullseye AS builder
 
-ENV GOOS=linux
-ENV GOARCH=amd64
-
 WORKDIR /go/src/github.com/110y/echoserver
 
 COPY go.mod go.mod

--- a/echoserver/internal/server/server.go
+++ b/echoserver/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/textproto"
 
 	"github.com/110y/servergroup"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -25,6 +26,14 @@ var (
 )
 
 var allowAllHeaderMatcher = func(key string) (string, bool) {
+	canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
+
+	// Authorization header will be passed through to the grpc server by default. So, ignore it.
+	// https://github.com/grpc-ecosystem/grpc-gateway/blob/fe9f8e44508964f5c490bb36c17db8240df3e213/runtime/context.go#L123-L125
+	if canonicalKey == "Authorization" {
+		return "", false
+	}
+
 	return key, true
 }
 


### PR DESCRIPTION
- echoserver: fix the header propagation for the authorization header
- add `.dockerignore`
- Remove GOOS and GOARCH from Dockerfile